### PR TITLE
Matrix Inversion

### DIFF
--- a/.vscode/matrix-sinppets.code-snippets
+++ b/.vscode/matrix-sinppets.code-snippets
@@ -1,0 +1,31 @@
+{
+    // Place your raytracer workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and 
+    // description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope 
+    // is left empty or omitted, the snippet gets applied to all languages. The prefix is what is 
+    // used to trigger the snippet and the body will be expanded and inserted. Possible variables are: 
+    // $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders. 
+    // Placeholders with the same ids are connected.
+    // Example:
+    // "Print to console": {
+    // 	"scope": "javascript,typescript",
+    // 	"prefix": "log",
+    // 	"body": [
+    // 		"console.log('$1');",
+    // 		"$2"
+    // 	],
+    // 	"description": "Log output to console"
+    // }
+    "4x4 matrix": {
+        "scope": "rust",
+        "prefix": "fourByfourMatrix",
+        "description": "Convenient snippet to create and fill 4x4 matrices",
+        "body": [
+            "let $1 = Matrix::from([",
+            "\t[$2, $3, $4, $5],",
+            "\t[$6, $7, $8, $9],",
+            "\t[$10, $11, $12, $13],",
+            "\t[$14, $15, $16, $0],",
+            "]);"
+        ]
+    }
+}

--- a/src/matrix/matrix.rs
+++ b/src/matrix/matrix.rs
@@ -152,6 +152,48 @@ impl<const M: usize, const N: usize> Matrix<M, N> {
 
         transposed
     }
+
+    /// Extracts the submatrix by eliminating the specified
+    /// row and column from the current matrix.
+    pub fn submatrix<const P: usize, const Q: usize>(
+        &self,
+        row: usize,
+        col: usize,
+    ) -> Result<Matrix<P, Q>> {
+        if P != M - 1 || Q != N - 1 {
+            return Err(Error::msg(
+                "Wrong submatrix dimensions. \
+                sorry, I am asking you to enter this,\
+             rust generic constants are dumb",
+            ));
+        }
+
+        let mut mat = Matrix::<P, Q>::default();
+
+        let mut _k = 0;
+        let mut _l = 0;
+
+        for i in 0..M {
+            for j in 0..N {
+                if i <= row {
+                    _k = i;
+                } else {
+                    _k = i - 1;
+                }
+
+                if j <= col {
+                    _l = j;
+                } else {
+                    _l = j - 1;
+                }
+
+                if i != row && j != col {
+                    mat[_k][_l] = self[i][j];
+                }
+            }
+        }
+        Ok(mat)
+    }
 }
 
 impl<const M: usize, const N: usize> From<[[f64; N]; M]> for Matrix<M, N> {
@@ -240,8 +282,104 @@ impl<const M: usize, const N: usize> Default for Matrix<M, N> {
     }
 }
 
+#[allow(dead_code)]
+/// Some matrix operations don't need a reference to `self`. This module is
+/// meant to contain those static functions that do not require instantiation
+/// of [Matrix] instances
+mod static_operations {
+    use super::Matrix;
+    use anyhow::{Error, Result};
+
+    /// Calculates the determinant of a 2x2 matrix
+    pub(super) fn determinant_2x2(matrix: &Matrix<2, 2>) -> f64 {
+        (matrix[0][0] * matrix[1][1]) - (matrix[0][1] * matrix[1][0])
+    }
+
+    pub(super) fn minor_3x3(matrix: &Matrix<3, 3>, row: usize, col: usize) -> Result<f64> {
+        let sub_matrix = matrix.submatrix::<2, 2>(row, col)?;
+        Ok(determinant_2x2(&sub_matrix))
+    }
+
+    pub(super) fn cofactor_3x3(matrix: &Matrix<3, 3>, row: usize, col: usize) -> Result<f64> {
+        let minor = minor_3x3(matrix, row, col)?;
+
+        if (row + col) % 2 == 0 {
+            Ok(minor)
+        } else {
+            Ok(-minor)
+        }
+    }
+
+    pub(super) fn determinant_3x3(matrix: &Matrix<3, 3>) -> Result<f64> {
+        let mut det = 0_f64;
+
+        for col in 0..3 {
+            det += matrix[0][col] * cofactor_3x3(matrix, 0, col)?;
+        }
+
+        Ok(det)
+    }
+
+    pub(super) fn minor_4x4(matrix: &Matrix<4, 4>, row: usize, col: usize) -> Result<f64> {
+        let sub_matrix = matrix.submatrix::<3, 3>(row, col)?;
+        determinant_3x3(&sub_matrix)
+    }
+
+    pub(super) fn cofactor_4x4(matrix: &Matrix<4, 4>, row: usize, col: usize) -> Result<f64> {
+        let minor = minor_4x4(matrix, row, col)?;
+
+        if (row + col) % 2 == 0 {
+            Ok(minor)
+        } else {
+            Ok(-minor)
+        }
+    }
+
+    pub(super) fn determinant_4x4(matrix: &Matrix<4, 4>) -> Result<f64> {
+        let mut det = 0_f64;
+
+        for col in 0..4 {
+            det += matrix[0][col] * cofactor_4x4(matrix, 0, col)?;
+        }
+
+        Ok(det)
+    }
+
+    pub(super) fn is_invertible_2x2(matrix: &Matrix<2, 2>) -> bool {
+        determinant_2x2(matrix) != 0.0
+    }
+
+    pub(super) fn is_invertible_3x3(matrix: &Matrix<3, 3>) -> Result<bool> {
+        Ok(determinant_3x3(matrix)? != 0.0)
+    }
+
+    pub(super) fn is_invertible_4x4(matrix: &Matrix<4, 4>) -> Result<bool> {
+        Ok(determinant_4x4(matrix)? != 0.0)
+    }
+
+    pub(super) fn inverse_4x4(matrix: &Matrix<4, 4>) -> Result<Matrix<4, 4>> {
+        if !is_invertible_4x4(matrix)? {
+            return Err(Error::msg("Matrix is not invertible"));
+        }
+
+        let mut inverse = Matrix::<4, 4>::new();
+
+        for row in 0..4 {
+            for col in 0..4 {
+                inverse[col][row] = cofactor_4x4(matrix, row, col)? / determinant_4x4(matrix)?
+            }
+        }
+
+        Ok(inverse)
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::static_operations::{
+        cofactor_3x3, determinant_2x2, determinant_3x3, determinant_4x4, inverse_4x4,
+        is_invertible_2x2, is_invertible_3x3, is_invertible_4x4, minor_3x3,
+    };
     use super::Matrix;
     use crate::spatial::Tuple;
     use anyhow::Result;
@@ -453,6 +591,186 @@ mod tests {
         // The identity matrix transposed is the same as the original matrix
         let identity_4x4 = Matrix::<4, 4>::identity()?;
         assert_eq!(identity_4x4.transpose(), identity_4x4.clone());
+
+        Ok(())
+    }
+
+    #[test]
+    fn determinant_2x2_works() {
+        let m = Matrix::from([[1.0, 5.0], [-3.0, 2.0]]);
+        assert_eq!(determinant_2x2(&m), 17.0);
+    }
+
+    #[test]
+    fn submatrix_calculation() -> Result<()> {
+        let m = Matrix::from([
+            [-6.0, 1.0, 1.0, 6.0],
+            [-8.0, 5.0, 8.0, 6.0],
+            [-1.0, 0.0, 8.0, 2.0],
+            [-7.0, 1.0, -1.0, 1.0],
+        ]);
+
+        let sub_m = m.submatrix::<3, 3>(2, 1)?;
+
+        assert_eq!(
+            sub_m,
+            Matrix::from([[-6.0, 1.0, 6.0], [-8.0, 8.0, 6.0], [-7.0, -1.0, 1.0],])
+        );
+
+        let sub_m_b = m.submatrix::<3, 3>(0, 0)?;
+
+        assert_eq!(
+            sub_m_b,
+            Matrix::from([[5.0, 8.0, 6.0], [0.0, 8.0, 2.0], [1.0, -1.0, 1.0],])
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn minor_of_a_3x3_matrix() -> Result<()> {
+        let m = Matrix::from([[3.0, 5.0, 0.0], [2.0, -1.0, -7.0], [6.0, -1.0, 5.0]]);
+        let actual_minor = minor_3x3(&m, 1, 0)?;
+        assert_eq!(actual_minor, 25.0);
+        Ok(())
+    }
+
+    #[test]
+    fn cofactor_of_a_3x3_matrix() -> Result<()> {
+        let m = Matrix::from([[3.0, 5.0, 0.0], [2.0, -1.0, -7.0], [6.0, -1.0, 5.0]]);
+
+        let minor_a = minor_3x3(&m, 0, 0)?;
+        let cofactor_a = cofactor_3x3(&m, 0, 0)?;
+        assert_eq!(cofactor_a, -12.0);
+        assert_eq!(cofactor_a, minor_a);
+
+        let minor_b = minor_3x3(&m, 1, 0)?;
+        let cofactor_b = cofactor_3x3(&m, 1, 0)?;
+        assert_eq!(cofactor_b, -25.0);
+        assert_eq!(cofactor_b, -minor_b);
+
+        Ok(())
+    }
+
+    #[test]
+    fn determinant_of_a_3x3_matrix() -> Result<()> {
+        let m = Matrix::from([[1.0, 2.0, 6.0], [-5.0, 8.0, -4.0], [2.0, 6.0, 4.0]]);
+        assert_eq!(determinant_3x3(&m)?, -196.0);
+        Ok(())
+    }
+
+    #[test]
+    fn determinant_of_a_4x4_matrix() -> Result<()> {
+        let m = Matrix::from([
+            [-2.0, -8.0, 3.0, 5.0],
+            [-3.0, 1.0, 7.0, 3.0],
+            [1.0, 2.0, -9.0, 6.0],
+            [-6.0, 7.0, 7.0, -9.0],
+        ]);
+        assert_eq!(determinant_4x4(&m)?, -4071.0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn is_invertible_checks() -> Result<()> {
+        let m_2 = Matrix::from([[1.0, 5.0], [-3.0, 2.0]]);
+        let m_2_non_invertible = Matrix::from([[1.0, 1.0], [1.0, 1.0]]);
+        assert!(is_invertible_2x2(&m_2));
+        assert!(!is_invertible_2x2(&m_2_non_invertible));
+
+        let m_3 = Matrix::from([[1.0, 2.0, 6.0], [-5.0, 8.0, -4.0], [2.0, 6.0, 4.0]]);
+        let m_3_non_invertible = Matrix::from([[1.0, 2.0, 3.0], [2.0, 4.0, 6.0], [1.0, 2.0, 3.0]]);
+        assert!(is_invertible_3x3(&m_3)?);
+        assert!(!is_invertible_3x3(&m_3_non_invertible)?);
+
+        let m_4 = Matrix::from([
+            [-2.0, -8.0, 3.0, 5.0],
+            [-3.0, 1.0, 7.0, 3.0],
+            [1.0, 2.0, -9.0, 6.0],
+            [-6.0, 7.0, 7.0, -9.0],
+        ]);
+
+        let m_4_non_invertible = Matrix::from([
+            [-2.0, -8.0, 1.0, 1.0],
+            [-2.0, -8.0, 1.0, 1.0],
+            [1.0, 4.0, 1.0, 1.0],
+            [1.0, 4.0, 1.0, 1.0],
+        ]);
+        assert!(is_invertible_4x4(&m_4)?);
+        assert!(!is_invertible_4x4(&m_4_non_invertible)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn inverse_of_4x4_matrices_works() -> Result<()> {
+        let mat_1 = Matrix::from([
+            [-5.0, 2.0, 6.0, -8.0],
+            [1.0, -5.0, 1.0, 8.0],
+            [7.0, 7.0, -6.0, -7.0],
+            [1.0, -3.0, 7.0, 4.0],
+        ]);
+
+        let mat_1_inverse = Matrix::from([
+            [0.21805, 0.45113, 0.24060, -0.04511],
+            [-0.80827, -1.45677, -0.44361, 0.52068],
+            [-0.07895, -0.22368, -0.05263, 0.19737],
+            [-0.52256, -0.81391, -0.30075, 0.30639],
+        ]);
+
+        assert_eq!(inverse_4x4(&mat_1)?, mat_1_inverse);
+
+        let mat_2 = Matrix::from([
+            [9.0, 3.0, 0.0, 9.0],
+            [-5.0, -2.0, -6.0, -3.0],
+            [-4.0, 9.0, 6.0, 4.0],
+            [-7.0, 6.0, 6.0, 2.0],
+        ]);
+
+        let mat_2_inverse = Matrix::from([
+            [-0.04074, -0.07778, 0.14444, -0.22222],
+            [-0.07778, 0.03333, 0.36667, -0.33333],
+            [-0.02901, -0.14630, -0.10926, 0.12963],
+            [0.17778, 0.06667, -0.26667, 0.33333],
+        ]);
+
+        assert_eq!(inverse_4x4(&mat_2)?, mat_2_inverse);
+
+        let mat_3 = Matrix::from([
+            [8.0, -5.0, 9.0, 2.0],
+            [7.0, 5.0, 6.0, 1.0],
+            [-6.0, 0.0, 9.0, 6.0],
+            [-3.0, 0.0, -9.0, -4.0],
+        ]);
+
+        let mat_3_inverse = Matrix::from([
+            [-0.15385, -0.15385, -0.28205, -0.53846],
+            [-0.07692, 0.12308, 0.02564, 0.03077],
+            [0.35897, 0.35897, 0.43590, 0.92308],
+            [-0.69231, -0.69231, -0.76923, -1.92308],
+        ]);
+
+        assert_eq!(inverse_4x4(&mat_3)?, mat_3_inverse);
+
+        // Test case to check that A*B = C, and C*inverse(B) = A
+        let a = Matrix::from([
+            [3.0, -9.0, 7.0, 3.0],
+            [3.0, -8.0, 2.0, -9.0],
+            [-4.0, 4.0, 4.0, 1.0],
+            [-6.0, 5.0, -1.0, 1.0],
+        ]);
+
+        let b = Matrix::from([
+            [8.0, 2.0, 2.0, 2.0],
+            [3.0, -1.0, 7.0, 0.0],
+            [7.0, 0.0, 5.0, 4.0],
+            [6.0, -2.0, 0.0, 5.0],
+        ]);
+
+        let c = b.multiply(&a)?;
+
+        assert_eq!(inverse_4x4(&b)?.multiply(&c)?, a);
 
         Ok(())
     }

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -1,4 +1,5 @@
 #[allow(clippy::module_inception)]
 mod matrix;
 
+pub use matrix::static_operations::inverse_4x4;
 pub use matrix::Matrix;


### PR DESCRIPTION
Implements one of the most important core functionality of the `Matrix` struct: inversion. I also reorganized some matrix operations into their own module. The main reason for that is my choice to use generics. It is not very easy to implement those functions for all general cases, and I had to implement them for specific cases where M and N are square matrices of size 2, 3, and 4.

This PR contains the building blocks, tests, docs, and implementation for the following:

- For 2x2, 3x3, and 4x4 matrices:
   - determinants 
   - cofactors
   - minors
   - is_invertible

- For 4x4 matrices only:
   - inverse

I also added a convenient snippet to allow me to easily create 4x4 matrices in VSCode. It was getting rather tedious to type out the `Matrix::from(...` stuff each time I wanted to create a 4x4 matrix.
