### PR TITLE
Implement sufrace normals and reflections

### DIFF
--- a/src/intersections/mod.rs
+++ b/src/intersections/mod.rs
@@ -2,8 +2,6 @@ mod objects;
 mod operations;
 mod ray;
 
-pub use objects::Intersection;
-pub use objects::Object;
-pub use objects::Sphere;
-pub use operations::{hit, transform_ray};
+pub use objects::{Intersection, Object, Sphere, SurfaceNormal};
+pub use operations::{hit, reflect, transform_ray};
 pub use ray::Ray;

--- a/src/spatial/tuple.rs
+++ b/src/spatial/tuple.rs
@@ -142,6 +142,10 @@ impl Tuple {
     pub fn get_w(&self) -> f64 {
         self.w.value() as f64
     }
+
+    pub fn convert_to_vector(&self) -> Tuple {
+        Tuple::vector(self.x, self.y, self.z)
+    }
 }
 
 impl ops::Add<&Tuple> for &Tuple {

--- a/src/spatial/tuple.rs
+++ b/src/spatial/tuple.rs
@@ -143,6 +143,8 @@ impl Tuple {
         self.w.value() as f64
     }
 
+    /// Returns a vector with the x,y,z values
+    /// of the current [Tuple]
     pub fn convert_to_vector(&self) -> Tuple {
         Tuple::vector(self.x, self.y, self.z)
     }
@@ -453,5 +455,17 @@ mod tests {
 
         assert_eq!(a.cross(&b), Tuple::vector(-1, 2, -1));
         assert_eq!(b.cross(&a), Tuple::vector(1, -2, 1));
+    }
+
+    #[test]
+    fn convert_to_vector_works() {
+        let p = Tuple::point(2, 3, 4);
+
+        // case 1: point to vector
+        assert_eq!(p.convert_to_vector(), Tuple::vector(2, 3, 4));
+
+        let v = Tuple::vector(2, 4, 5);
+        // case 2: vector to vector
+        assert_eq!(v.convert_to_vector(), Tuple::vector(2, 4, 5));
     }
 }


### PR DESCRIPTION
This PR includes implementations to find the surface normals for points on a sphere, accounting for possible transformations. Furthermore, we implement an operation to calculate reflected vectors for inbound vectors in relation to a normal.

I added a `convert_to_vector` method in the Tuple implementation since the surface normal calculation could mess with the `w` value for the result. This method does not mutate the original Tuple, but instead returns a new one.