### PR TITLE
Build a world!

### DIFF
--- a/src/color/color.rs
+++ b/src/color/color.rs
@@ -2,7 +2,7 @@ use crate::utils::float_equals;
 use std::fmt::Display;
 use std::ops;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialOrd)]
 /// Representation of colors using RGB values
 pub struct Color {
     pub red: f64,

--- a/src/intersections/mod.rs
+++ b/src/intersections/mod.rs
@@ -2,6 +2,133 @@ mod objects;
 mod operations;
 mod ray;
 
-pub use objects::{Object, Sphere, SurfaceNormal};
-pub use operations::{hit, reflect, transform_ray, Intersection};
+pub use objects::{Intersect, Object, Sphere, SurfaceNormal};
+pub use operations::{hit, reflect, transform_ray};
 pub use ray::Ray;
+
+use crate::spatial::Tuple;
+use anyhow::Result;
+
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
+/// Data structure to keep track of intersections
+/// for a given object
+pub struct Intersection {
+    pub t: f64,
+    pub object: Object,
+}
+
+impl Intersection {
+    /// Create a new Intersection for a given object using
+    /// the calculated `t` value of a Ray intersecting `object`
+    pub fn new(t: impl Into<f64>, object: Object) -> Self {
+        Self {
+            t: t.into(),
+            object,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+/// Struct containing pre-computed values using rays and intersections
+pub struct Computations {
+    t: f64,
+    object: Object,
+    point: Tuple,
+    eyev: Tuple,
+    normalv: Tuple,
+    inside: bool,
+}
+
+impl Computations {
+    /// Get a reference to the object in the computation
+    pub fn get_object(&self) -> &Object {
+        &self.object
+    }
+
+    /// Gets the point of the intersection of a ray and object
+    pub fn get_point(&self) -> &Tuple {
+        &self.point
+    }
+
+    /// Gets the eye vector for this computation
+    pub fn get_eyev(&self) -> &Tuple {
+        &self.eyev
+    }
+
+    /// Gets the normal vector for this computation
+    pub fn get_normalv(&self) -> &Tuple {
+        &self.normalv
+    }
+
+    /// Builds a state of the world based on the given intersection and ray
+    /// values. This computation is performed to make some commonly accessed
+    /// state values easily accessible in other computations.
+    pub fn prepare_computations(i: &Intersection, r: &Ray) -> Result<Self> {
+        // Copy intersection's properties for convenience
+        let t = i.t;
+        let object = i.object;
+
+        // Precompute some useful values
+        let point = r.position(t);
+        let eyev = -r.direction;
+        let mut normalv = object.normal_at(point)?;
+        let mut inside = false;
+
+        if normalv.dot(&eyev) < 0.0 {
+            inside = true;
+            normalv = -normalv;
+        }
+
+        Ok(Self {
+            t,
+            object,
+            point,
+            eyev,
+            normalv,
+            inside,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::spatial::Tuple;
+
+    use super::{Computations, Intersection, Object, Ray, Sphere};
+    use anyhow::Result;
+
+    #[test]
+    fn precomputing_state_of_intersection_when_it_is_outside() -> Result<()> {
+        let ray = Ray::new(Tuple::point(0, 0, -5), Tuple::vector(0, 0, 1))?;
+        let sphere = Sphere::new();
+        let intersection = Intersection::new(4, Object::Sphere(sphere));
+
+        let comps = Computations::prepare_computations(&intersection, &ray)?;
+
+        assert_eq!(comps.t, intersection.t);
+        assert_eq!(comps.object, Object::Sphere(sphere));
+        assert_eq!(comps.point, Tuple::point(0, 0, -1));
+        assert_eq!(comps.eyev, Tuple::vector(0, 0, -1));
+        assert_eq!(comps.normalv, Tuple::vector(0, 0, -1));
+        assert!(!comps.inside);
+
+        Ok(())
+    }
+
+    #[test]
+    fn precomputing_state_of_intersection_when_it_is_inside() -> Result<()> {
+        let ray = Ray::new(Tuple::point(0, 0, 0), Tuple::vector(0, 0, 1))?;
+        let sphere = Sphere::new();
+        let intersection = Intersection::new(1, Object::Sphere(sphere));
+
+        let comps = Computations::prepare_computations(&intersection, &ray)?;
+
+        assert_eq!(comps.t, 1.0);
+        assert_eq!(comps.point, Tuple::point(0, 0, 1));
+        assert_eq!(comps.eyev, Tuple::vector(0, 0, -1));
+        assert!(comps.inside);
+        assert_eq!(comps.normalv, Tuple::vector(0, 0, -1));
+
+        Ok(())
+    }
+}

--- a/src/intersections/operations.rs
+++ b/src/intersections/operations.rs
@@ -1,4 +1,4 @@
-use super::{Object, Ray};
+use super::{Intersection, Ray};
 use crate::{matrix::Matrix, spatial::Tuple};
 use anyhow::Result;
 use core::f64;
@@ -23,25 +23,6 @@ pub fn hit(xs: Vec<Intersection>) -> Option<Intersection> {
     }
 
     result
-}
-
-#[derive(Debug, Copy, Clone, PartialEq)]
-/// Data structure to keep track of intersections
-/// for a given object
-pub struct Intersection {
-    pub t: f64,
-    pub object: Object,
-}
-
-impl Intersection {
-    /// Create a new Intersection for a given object using
-    /// the calculated `t` value of a Ray intersecting `object`
-    pub fn new(t: impl Into<f64>, object: Object) -> Self {
-        Self {
-            t: t.into(),
-            object,
-        }
-    }
 }
 
 /// Transforms a ray by performing a matrix multiplication

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,14 @@ pub mod matrix;
 /// with various types of objects
 pub mod intersections;
 
+/// Contains the implementation of point lights, materials, and the
+/// Phong reflection model to simulate the interaction of light with
+/// objects
 pub mod lights;
+
+/// Contains representation of the world that contains lights
+/// and objects
+pub mod world;
 
 /// The `spatial` module contains the representation for key
 /// three-dimensional spatial properties like Points and Vectors

--- a/src/lights/light.rs
+++ b/src/lights/light.rs
@@ -3,7 +3,7 @@ use anyhow::{Error, Result};
 
 use super::Material;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 /// Data structure representing a light source. A light source
 /// has a position in space, and a specific color
 pub struct PointLight {

--- a/src/lights/material.rs
+++ b/src/lights/material.rs
@@ -2,7 +2,7 @@ use typed_floats::tf64::Positive;
 
 use crate::{color::Color, utils::float_equals};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialOrd)]
 /// Data structure capturing attributes such as surface color,
 /// shininess, diffusion, specular, and ambience. These materials
 /// are then associated with objects to give them these properties.

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use std::f64::consts::PI;
 use anyhow::Result;
 use raytracer::canvas::Canvas;
 use raytracer::color::Color;
-use raytracer::intersections::{hit, Ray, Sphere, SurfaceNormal};
+use raytracer::intersections::{hit, Ray, Sphere};
 use raytracer::lights::{lighting, PointLight};
 use raytracer::matrix::{rotation_z, scaling, translation};
 use raytracer::spatial::Tuple;

--- a/src/matrix/matrix.rs
+++ b/src/matrix/matrix.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::{spatial::Tuple, utils::float_equals};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialOrd)]
 /// Representation of a Matrix of dimension `M x N`
 /// containing [f64] values
 ///

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -1,0 +1,213 @@
+use crate::{
+    color::Color,
+    intersections::{hit, Computations, Intersect, Intersection, Object, Ray, Sphere},
+    lights::{lighting, PointLight},
+    matrix::scaling,
+    spatial::Tuple,
+};
+use anyhow::Result;
+
+#[derive(Debug, Clone, PartialEq)]
+/// Data structure representing the world that contains
+/// objects and a light source
+pub struct World {
+    pub light: Option<PointLight>,
+    pub objects: Vec<Object>,
+}
+
+impl World {
+    /// Creates a new empty world
+    pub fn new() -> Self {
+        Self {
+            light: None,
+            objects: vec![],
+        }
+    }
+
+    /// Return a reference to the light in the world
+    pub fn get_light(&self) -> Option<&PointLight> {
+        self.light.as_ref()
+    }
+
+    /// Set the world light source
+    pub fn set_light(&mut self, light: Option<PointLight>) {
+        self.light = light;
+    }
+
+    /// Finds and returns all the intersections of the given ray
+    /// with the world
+    fn intersect_world(&self, ray: &Ray) -> Result<Vec<Intersection>> {
+        let mut xs: Vec<Intersection> = vec![];
+        for o in &self.objects {
+            let mut intersections = o.intersect(ray)?;
+            xs.append(&mut intersections);
+        }
+
+        xs.sort_by(|a, b| a.t.partial_cmp(&b.t).unwrap());
+
+        Ok(xs)
+    }
+
+    /// Given a set of pre-computed state values of the world,
+    /// calculate the color of a hit in the world
+    fn shade_hit(&self, comps: &Computations) -> Color {
+        if self.light.is_none() {
+            return Color::black();
+        }
+
+        lighting(
+            &comps.get_object().get_material(),
+            self.light.as_ref().unwrap(),
+            comps.get_point(),
+            comps.get_eyev(),
+            comps.get_normalv(),
+        )
+    }
+
+    /// This method calculates all the intersections of a given ray
+    /// in the world with the objects in it, and uses this information
+    /// to find the color at the hits from the input ray.
+    pub fn color_at(&self, ray: &Ray) -> Result<Color> {
+        let xs = self.intersect_world(ray)?;
+        let h = hit(xs);
+
+        if h.is_none() {
+            return Ok(Color::black());
+        }
+
+        let comps = Computations::prepare_computations(h.as_ref().unwrap(), ray)?;
+        Ok(self.shade_hit(&comps))
+    }
+}
+
+impl Default for World {
+    fn default() -> Self {
+        let light_source =
+            PointLight::new(Tuple::point(-10, 10, -10), Color::new(1, 1, 1)).unwrap();
+
+        let mut s1 = Sphere::new();
+        s1.material.set_color(Color::new(0.8, 1.0, 0.6));
+        s1.material.set_diffuse(0.7);
+        s1.material.set_specular(0.2);
+
+        let mut s2 = Sphere::new();
+        s2.set_transform(scaling(0.5, 0.5, 0.5));
+
+        Self {
+            light: Some(light_source),
+            objects: vec![Object::Sphere(s1), Object::Sphere(s2)],
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::World;
+    use crate::{
+        color::Color,
+        intersections::{Computations, Intersection, Ray},
+        lights::PointLight,
+        spatial::Tuple,
+    };
+    use anyhow::Result;
+
+    #[test]
+    fn new_world_is_empty() {
+        let w = World::new();
+        assert_eq!(w.get_light(), None);
+        assert_eq!(w.objects.len(), 0);
+    }
+
+    #[test]
+    fn default_world_is_built_correctly() {
+        let w = World::default();
+
+        assert!(w.get_light().is_some());
+        assert_eq!(w.objects.len(), 2);
+    }
+
+    #[test]
+    fn intersect_world_default() -> Result<()> {
+        let w = World::default();
+        let ray = Ray::new(Tuple::point(0, 0, -5), Tuple::vector(0, 0, 1))?;
+
+        let xs = w.intersect_world(&ray)?;
+
+        assert_eq!(xs.len(), 4);
+        assert_eq!(xs[0].t, 4.0);
+        assert_eq!(xs[1].t, 4.5);
+        assert_eq!(xs[2].t, 5.5);
+        assert_eq!(xs[3].t, 6.0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn shading_an_intersection() -> Result<()> {
+        let w = World::default();
+        let r = Ray::new(Tuple::point(0, 0, -5), Tuple::vector(0, 0, 1))?;
+
+        // Ensure that we have two objects in our world
+        assert_eq!(w.objects.len(), 2);
+        let i = Intersection::new(4, w.objects[0]);
+        let comps = Computations::prepare_computations(&i, &r)?;
+
+        let c = w.shade_hit(&comps);
+
+        assert_eq!(c, Color::new(0.38066, 0.47583, 0.2855));
+
+        Ok(())
+    }
+
+    #[test]
+    fn shading_an_intersection_from_the_inside() -> Result<()> {
+        let mut w = World::default();
+        w.set_light(Some(PointLight::new(
+            Tuple::point(0, 0.25, 0),
+            Color::new(1, 1, 1),
+        )?));
+
+        let r = Ray::new(Tuple::point(0, 0, 0), Tuple::vector(0, 0, 1))?;
+
+        // Ensure that we have two objects in our world
+        assert_eq!(w.objects.len(), 2);
+        let i = Intersection::new(0.5, w.objects[1]);
+        let comps = Computations::prepare_computations(&i, &r)?;
+
+        let c = w.shade_hit(&comps);
+
+        assert_eq!(c, Color::new(0.90498, 0.90498, 0.90498));
+
+        Ok(())
+    }
+
+    #[test]
+    fn color_at_when_ray_misses() -> Result<()> {
+        let w = World::default();
+        let r = Ray::new(Tuple::point(0, 0, -5), Tuple::vector(0, 1, 0))?;
+        let c = w.color_at(&r)?;
+        assert_eq!(c, Color::black());
+        Ok(())
+    }
+
+    #[test]
+    fn color_at_when_a_ray_hits() -> Result<()> {
+        let w = World::default();
+        let r = Ray::new(Tuple::point(0, 0, -5), Tuple::vector(0, 0, 1))?;
+        let c = w.color_at(&r)?;
+        assert_eq!(c, Color::new(0.38066, 0.47583, 0.2855));
+        Ok(())
+    }
+
+    #[test]
+    fn color_at_when_intersection_is_behind_ray() -> Result<()> {
+        let mut w = World::default();
+        w.objects[0].set_ambient(1.0);
+        w.objects[1].set_ambient(1.0);
+
+        let r = Ray::new(Tuple::point(0, 0, 0.75), Tuple::vector(0, 0, -1))?;
+        let c = w.color_at(&r)?;
+        assert_eq!(c, w.objects[1].get_material().get_color());
+        Ok(())
+    }
+}


### PR DESCRIPTION
- Adds an `Intersect` and `SurfaceNormal` trait that should be implemented for all variants of the Object enum. This consolidates the ability to find intersections and normals regardless for the kind of object we are dealing with.

- Adds PartialOrd trait to various structs to ensure the intersection calculation for a world can return a sorted list of intersections.