### PR TITLE
Defining a view transform

### DIFF
--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -4,4 +4,6 @@ mod transformations;
 
 pub use matrix::static_operations::inverse_4x4;
 pub use matrix::Matrix;
-pub use transformations::{rotation_x, rotation_y, rotation_z, scaling, shearing, translation};
+pub use transformations::{
+    rotation_x, rotation_y, rotation_z, scaling, shearing, translation, view_transform,
+};


### PR DESCRIPTION
Get a view transformation matrix so that the world can be re-oriented (or rather the eye vector with respect to the world).