### PR TITLE
Add support for shadows

### DIFF
--- a/src/intersections/mod.rs
+++ b/src/intersections/mod.rs
@@ -61,6 +61,11 @@ impl Computations {
         &self.normalv
     }
 
+    /// Get the over point value for the computation
+    ///
+    /// This over point sits just a bit above the surface and is used
+    /// to correct for the margin of error that arises from floating
+    /// point calculations of ray intersections.
     pub fn get_over_point(&self) -> &Tuple {
         &self.over_point
     }

--- a/src/intersections/mod.rs
+++ b/src/intersections/mod.rs
@@ -6,7 +6,7 @@ pub use objects::{Intersect, Object, Sphere, SurfaceNormal};
 pub use operations::{hit, reflect, transform_ray};
 pub use ray::Ray;
 
-use crate::spatial::Tuple;
+use crate::{spatial::Tuple, utils::EPSILON};
 use anyhow::Result;
 
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
@@ -37,6 +37,7 @@ pub struct Computations {
     eyev: Tuple,
     normalv: Tuple,
     inside: bool,
+    over_point: Tuple,
 }
 
 impl Computations {
@@ -60,6 +61,10 @@ impl Computations {
         &self.normalv
     }
 
+    pub fn get_over_point(&self) -> &Tuple {
+        &self.over_point
+    }
+
     /// Builds a state of the world based on the given intersection and ray
     /// values. This computation is performed to make some commonly accessed
     /// state values easily accessible in other computations.
@@ -79,6 +84,8 @@ impl Computations {
             normalv = -normalv;
         }
 
+        let over_point = point + (&normalv * EPSILON);
+
         Ok(Self {
             t,
             object,
@@ -86,6 +93,7 @@ impl Computations {
             eyev,
             normalv,
             inside,
+            over_point,
         })
     }
 }

--- a/src/intersections/objects.rs
+++ b/src/intersections/objects.rs
@@ -161,9 +161,11 @@ mod tests {
     use super::{Intersection, Object, Ray, Sphere};
     use crate::{
         color::Color,
+        intersections::Computations,
         lights::Material,
         matrix::{rotation_z, scaling, translation, Matrix},
         spatial::Tuple,
+        utils::EPSILON,
     };
     use anyhow::Result;
 
@@ -347,5 +349,20 @@ mod tests {
         s.set_material(m);
         assert_eq!(s.material.get_color(), Color::green());
         assert_eq!(s.material.get_ambient(), 0.5);
+    }
+
+    #[test]
+    fn the_hit_should_offset_the_point() -> Result<()> {
+        let r = Ray::new(Tuple::point(0, 0, -5), Tuple::vector(0, 0, 1))?;
+        let mut shape = Sphere::default();
+        shape.set_transform(translation(0, 0, 1));
+
+        let i = Intersection::new(5, Object::Sphere(shape));
+        let comps = Computations::prepare_computations(&i, &r)?;
+
+        assert!(comps.get_over_point().get_z() < -EPSILON / 2.0);
+        assert!(comps.get_point().get_z() > comps.get_over_point().get_z());
+
+        Ok(())
     }
 }

--- a/src/lights/light.rs
+++ b/src/lights/light.rs
@@ -45,11 +45,16 @@ pub fn lighting(
     // combine surface color with the light's intensity/color
     let effective_color = material.get_color() * point_light.intensity;
 
-    // find the direction to the light source
-    let lightv = (&point_light.position - position).normalize();
-
     // compute ambient contribution
     let ambient = effective_color * material.get_ambient();
+
+    // if we're in a shadow, we can ignore the diffuse and specular components
+    if in_shadow {
+        return ambient;
+    }
+
+    // find the direction to the light source
+    let lightv = (&point_light.position - position).normalize();
 
     // light_dot_normal represents the cosine of the angle between the​
     // light vector and the normal vector. A negative number means the​
@@ -73,10 +78,6 @@ pub fn lighting(
             let factor = reflect_dot_eye.powf(material.get_shininess());
             specular = point_light.intensity * material.get_specular() * factor;
         }
-    }
-
-    if in_shadow {
-        return ambient;
     }
 
     ambient + diffuse + specular

--- a/src/lights/light.rs
+++ b/src/lights/light.rs
@@ -8,7 +8,7 @@ use super::Material;
 /// has a position in space, and a specific color
 pub struct PointLight {
     intensity: Color,
-    position: Tuple,
+    pub(crate) position: Tuple,
 }
 
 impl PointLight {
@@ -40,6 +40,7 @@ pub fn lighting(
     position: &Tuple,
     eyev: &Tuple,
     normalv: &Tuple,
+    in_shadow: bool,
 ) -> Color {
     // combine surface color with the light's intensity/color
     let effective_color = material.get_color() * point_light.intensity;
@@ -74,6 +75,10 @@ pub fn lighting(
         }
     }
 
+    if in_shadow {
+        return ambient;
+    }
+
     ambient + diffuse + specular
 }
 
@@ -93,8 +98,9 @@ mod tests {
         let eyev = Tuple::vector(0, 0, -1);
         let normal = Tuple::vector(0, 0, -1);
         let point_light = PointLight::new(Tuple::point(0, 0, -10), Color::new(1, 1, 1))?;
+        let in_shadow = false;
 
-        let result = lighting(&m, &point_light, &position, &eyev, &normal);
+        let result = lighting(&m, &point_light, &position, &eyev, &normal, in_shadow);
         let expected = Color::new(1.9, 1.9, 1.9);
 
         assert_eq!(result, expected);
@@ -110,8 +116,9 @@ mod tests {
         let eyev = Tuple::vector(0, SQRT_2 / 2.0, -SQRT_2 / 2.0);
         let normal = Tuple::vector(0, 0, -1);
         let point_light = PointLight::new(Tuple::point(0, 0, -10), Color::new(1, 1, 1))?;
+        let in_shadow = false;
 
-        let result = lighting(&m, &point_light, &position, &eyev, &normal);
+        let result = lighting(&m, &point_light, &position, &eyev, &normal, in_shadow);
         let expected = Color::new(1, 1, 1);
 
         assert_eq!(result, expected);
@@ -127,8 +134,9 @@ mod tests {
         let eyev = Tuple::vector(0, 0, -1);
         let normal = Tuple::vector(0, 0, -1);
         let point_light = PointLight::new(Tuple::point(0, 10, -10), Color::new(1, 1, 1))?;
+        let in_shadow = false;
 
-        let result = lighting(&m, &point_light, &position, &eyev, &normal);
+        let result = lighting(&m, &point_light, &position, &eyev, &normal, in_shadow);
         let expected = Color::new(0.7364, 0.7364, 0.7364);
 
         assert_eq!(result, expected);
@@ -144,8 +152,9 @@ mod tests {
         let eyev = Tuple::vector(0, -SQRT_2 / 2.0, -SQRT_2 / 2.0);
         let normal = Tuple::vector(0, 0, -1);
         let point_light = PointLight::new(Tuple::point(0, 10, -10), Color::new(1, 1, 1))?;
+        let in_shadow = false;
 
-        let result = lighting(&m, &point_light, &position, &eyev, &normal);
+        let result = lighting(&m, &point_light, &position, &eyev, &normal, in_shadow);
         let expected = Color::new(1.6364, 1.6364, 1.6364);
 
         assert_eq!(result, expected);
@@ -161,8 +170,27 @@ mod tests {
         let eyev = Tuple::vector(0, 0, -1);
         let normal = Tuple::vector(0, 0, -1);
         let point_light = PointLight::new(Tuple::point(0, 0, 10), Color::new(1, 1, 1))?;
+        let in_shadow = false;
 
-        let result = lighting(&m, &point_light, &position, &eyev, &normal);
+        let result = lighting(&m, &point_light, &position, &eyev, &normal, in_shadow);
+        let expected = Color::new(0.1, 0.1, 0.1);
+
+        assert_eq!(result, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn lighting_with_surface_in_shadow() -> Result<()> {
+        let m = Material::default();
+        let position = Tuple::point(0, 0, 0);
+
+        let eyev = Tuple::vector(0, 0, -1);
+        let normal = Tuple::vector(0, 0, -1);
+        let point_light = PointLight::new(Tuple::point(0, 0, -10), Color::new(1, 1, 1))?;
+        let in_shadow = true;
+
+        let result = lighting(&m, &point_light, &position, &eyev, &normal, in_shadow);
         let expected = Color::new(0.1, 0.1, 0.1);
 
         assert_eq!(result, expected);

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,7 +151,7 @@ fn cast_rays_on_sphere_3d() -> Result<()> {
                 let point = ray.position(cur_hit.unwrap().t);
                 let normal = s.normal_at(point)?;
                 let eye = -ray.direction;
-                let color = lighting(&s.material, &light, &point, &eye, &normal);
+                let color = lighting(&s.material, &light, &point, &eye, &normal, false); // placeholder until shadows are accounted for
 
                 canvas.write_pixel(x, y, color)?;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,7 +164,7 @@ fn cast_rays_on_sphere_3d() -> Result<()> {
 }
 
 #[allow(dead_code)]
-fn render_a_world_chapter_7() -> Result<()> {
+fn render_a_world_chapter_7(vsize: usize, hsize: usize) -> Result<()> {
     let mut floor_material = Material::default();
     floor_material.set_color(Color::new(1, 0.9, 0.9));
     floor_material.set_specular(0.0);
@@ -215,7 +215,7 @@ fn render_a_world_chapter_7() -> Result<()> {
     world.add_object(Object::Sphere(left));
     world.add_object(Object::Sphere(right));
 
-    let mut camera = Camera::new(100, 50, PI / 3.0);
+    let mut camera = Camera::new(hsize, vsize, PI / 3.0);
     camera.set_transform(view_transform(
         &Tuple::point(0, 1.5, -5),
         &Tuple::point(0, 1, 0),
@@ -251,7 +251,7 @@ fn main() -> Result<()> {
     // cast_rays_on_sphere_3d()?;
 
     // render a world from chapter 7
-    render_a_world_chapter_7()?;
+    render_a_world_chapter_7(500, 500)?;
 
     Ok(())
 }

--- a/src/utils/float_equals.rs
+++ b/src/utils/float_equals.rs
@@ -1,4 +1,4 @@
-const EPSILON: f64 = 0.00001;
+pub const EPSILON: f64 = 0.00001;
 
 /// Helper function to properly compare the equality
 /// of two 64-bit precision floating point numbers.

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,3 @@
 mod float_equals;
 
-pub use float_equals::float_equals;
+pub use float_equals::{float_equals, EPSILON};


### PR DESCRIPTION
This PR makes our renderer more complex by introducing the concept of shadows. When a point is calculated to be a shadowed point, we only render it's ambient color and ignore the light from the light sources.